### PR TITLE
Fix per quicksearch

### DIFF
--- a/Italian/main/QuickSearchBox.apk/res/values-it/strings.xml
+++ b/Italian/main/QuickSearchBox.apk/res/values-it/strings.xml
@@ -54,4 +54,7 @@
     <string name="cta_declaration_ignore">Non mostrare più</string>
     <string name="cta_declaration_positive_text">Consenti</string>
     <string name="cta_declaration_negative_text">Esci</string>
+    <string name="installed_apps_component">com.android.providers.applications/.ApplicationLauncher</string>
+    <string name="distance_unit_kilometer">km</string>
+    <string name="distance_unit_meter">m</string>
 </resources>


### PR DESCRIPTION
è stato inserito lo spazio prima di /> in 8,9, 10. Sono state aggiunte altre stringhe in accordo al repository principale
